### PR TITLE
Add VSCode launch settings.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,25 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${vcpkgRoot}/x64-windows/include",
+                "${vcpkgRoot}/x64-windows-static/include",
+                "${vcpkgRoot}/x86-windows/include",
+                "${vcpkgRoot}/x86-windows-static/include"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "windowsSdkVersion": "10.0.18362.0",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-msvc-x64",
+            "configurationProvider": "ms-vscode.cmake-tools"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools", // C/C++
+        "austin.code-gnu-global", // C++ Intellisense
+        "twxs.cmake", // CMake
+        "ms-vscode.cmake-tools", // CMake Tools
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                // Add libraries from tcod to the runtime PATH.
+                {"name": "Path", "value": "${env:Path};${workspaceFolder}/tcod"}
+            ],
+            "console": "internalConsole",
+        }
+    ]
+}


### PR DESCRIPTION
This integrates with CMake and should let you test and run the project more quickly and easily. Relevant extensions will be recommended by `extensions.json`.  The launcher mostly uses CMake Tools.

The tcod folder is added to `PATH` on launch.  So you don't need to move any files around other than manually installing tcod.

Only Windows settings were added, but it shouldn't be too difficult to add more using the current settings as a reference. Other files could be added like `settings.json` but I haven't messed with them yet.

Once CMake Tools is installed, allow it to configure the project, then configure CMake Tools using the status bar along the bottom of the IDE.  The `roguelike` project should be selected for example.  Then use the Run tab from the top menu to start the game.