### PR TITLE
Enable warnings reccomended for new projects.  Fixed 2 major issues, and a few minor issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/tcod/libtcod.lib)
 
+if (MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W4)
+else()
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+endif()
+
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES

--- a/include/Pataro/Actor.hpp
+++ b/include/Pataro/Actor.hpp
@@ -63,7 +63,7 @@ namespace pat
         inline const std::string& get_name() const { return m_name; }
 
         inline bool is_blocking() const { return m_blocks; }
-        inline void set_blocking(bool value) { m_blocks = false; }
+        inline void set_blocking(bool value) { m_blocks = value; }
 
         inline actor::Attacker*     attacker() { return m_attacker.get(); }
         inline actor::Destructible* destructible() { return m_destructible.get(); }

--- a/include/Pataro/Actor/AI.hpp
+++ b/include/Pataro/Actor/AI.hpp
@@ -12,6 +12,8 @@ namespace pat::actor
     class AI
     {
     public:
+        virtual ~AI() = default;
+
         /**
          * @brief Update an entity with some intelligence
          * 

--- a/src/Pataro/Actor/Destructible.cpp
+++ b/src/Pataro/Actor/Destructible.cpp
@@ -26,7 +26,7 @@ float Destructible::take_damage(pat::Actor* owner, float damage, pat::Map* map)
     return damage;
 }
 
-void Destructible::die(pat::Actor* owner, pat::Map* map)
+void Destructible::die(pat::Actor* owner, [[maybe_unused]] pat::Map* map)
 {
     owner->morph_into('%', m_corpse_name, TCODColor::darkRed);
     owner->set_blocking(false);

--- a/src/Pataro/Map/BSPListener.cpp
+++ b/src/Pataro/Map/BSPListener.cpp
@@ -10,7 +10,7 @@ BSPListener::BSPListener(Level* level) :
     m_level(level), m_room_nb(0)
 {}
 
-bool BSPListener::visitNode(TCODBsp* node, void* userData)
+bool BSPListener::visitNode(TCODBsp* node, [[maybe_unused]] void* userData)
 {
     if (node->isLeaf())
     {

--- a/src/Pataro/Map/Level.cpp
+++ b/src/Pataro/Map/Level.cpp
@@ -206,15 +206,15 @@ void Level::create_room(bool first_room, int x1, int y1, int x2, int y2)
             if (rng->getInt(0, 100) < 80)
             {
                 m_actors.emplace_back(std::make_shared<Actor>(x, y, 'o', "orc", TCODColor::desaturatedGreen));
-                m_actors.back()->set_attacker<actor::Attacker>(3);
-                m_actors.back()->set_destructible<actor::details::MonsterDestructible>(10, 0, "dead orc");
+                m_actors.back()->set_attacker<actor::Attacker>(3.0f);
+                m_actors.back()->set_destructible<actor::details::MonsterDestructible>(10.0f, 0.0f, "dead orc");
             }
             // create a troll
             else
             {
                 m_actors.emplace_back(std::make_shared<Actor>(x, y, 'T', "troll", TCODColor::darkerGreen));
-                m_actors.back()->set_attacker<actor::Attacker>(4);
-                m_actors.back()->set_destructible<actor::details::MonsterDestructible>(16, 1, "troll carcass");
+                m_actors.back()->set_attacker<actor::Attacker>(4.0f);
+                m_actors.back()->set_destructible<actor::details::MonsterDestructible>(16.0f, 1.0f, "troll carcass");
             }
 
             m_actors.back()->set_ai<actor::details::MonsterAI>();


### PR DESCRIPTION
I've added stricter compiler warnings to the CMake script.

The `set_blocking` method was ignoring its parameter and has been fixed.  The `AI` class was missing its destructor.