### PR TITLE
Use vcpkg for dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   BUILD_TYPE: Release
+  # Indicates the CMake build directory where project files and binaries are being produced.
+  CMAKE_BUILD_DIR: ${{ github.workspace }}/build/
+  # Indicates the location of the vcpkg as a Git submodule of the project repository.
+  VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
 jobs:
   build:
@@ -23,6 +27,11 @@ jobs:
             os: windows-latest, os_short: "Windows",
             build_type: "Release", cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+          }
+        - {
+            name: "Ubuntu GCC",
+            os: ubuntu-latest, os_short: "Ubuntu",
+            build_type: "Release", cc: "gcc", cxx: "g++"
           }
         - {
             name: "Ubuntu Latest GCC",
@@ -45,6 +54,22 @@ jobs:
       with:
         submodules: true
 
+    - name: Restore vcpkg and its artifacts
+      uses: actions/cache@v2
+      with:
+        # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
+        # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
+        # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
+        path: |
+          ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
+          ${{ env.VCPKG_ROOT }}
+          !${{ env.VCPKG_ROOT }}/buildtrees
+          !${{ env.VCPKG_ROOT }}/packages
+          !${{ env.VCPKG_ROOT }}/downloads
+        # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+        # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+        key: ${{ matrix.config.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json', '.git/modules/vcpkg/HEAD') }}
+
     - name: Update compilers
       if: ${{ matrix.config.cc }} == 'gcc' && ${{ matrix.config.os_short }} == 'Ubuntu'
       shell: bash
@@ -59,27 +84,13 @@ jobs:
           sudo apt-get install -y clang-9 lld-9 libc++-9-dev libc++abi-9-dev clang-tools-9
         elif [[ ${{ matrix.config.os_short }} == 'macOS' ]]; then
           brew install gcc && brew link gcc && CXX=/usr/local/bin/g++-9
-          brew install sdl2
-        elif [[ ${{ matrix.config.os_short }} == 'Windows' ]]; then
-          wget https://github.com/libtcod/libtcod/releases/download/1.16.0-alpha.15/libtcod-1.16.0-alpha.15-x86-msvc.zip
-          unzip libtcod-1.16.0-alpha.15-x86-msvc.zip
-          mv libtcod-1.16.0-alpha.15-x86-msvc tcod
-        fi
-        if [[ ${{ matrix.config.os_short }} == 'Ubuntu' ]]; then
-          sudo apt-get -yq install libsdl2-dev scons
-          wget https://github.com/libtcod/libtcod/archive/1.16.0-alpha.15.zip
-          unzip 1.16.0-alpha.15.zip
-          mv libtcod-1.16.0-alpha.15 tcod
-          (cd tcod/buildsys/scons; scons build)
-          ln -s tcod/include/ tcod/src/
-          cp tcod/buildsys/scons/libtcod-1.16.0-alpha.15-x86_64-DEBUG/libtcod.so tcod/
         fi
 
     - name: Configure CMake
       shell: bash
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }}
+      run: cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }}
 
     - name: Build
       shell: bash
       run: |
-        cmake --build build --config $BUILD_TYPE
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config $BUILD_TYPE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,6 @@ jobs:
             build_type: "Release", cc: "gcc", cxx: "g++"
           }
         - {
-            name: "Ubuntu Latest GCC",
-            os: ubuntu-latest, os_short: "Ubuntu",
-            build_type: "Release", cc: "gcc-8", cxx: "g++-8"
-          }
-        - {
-            name: "Ubuntu Latest Clang",
-            os: ubuntu-latest, os_short: "Ubuntu",
-            build_type: "Release", cc: "clang", cxx: "clang++"
-          }
-        - {
             name: "macOS Latest Clang",
             os: macos-latest, os_short: "macOS",
             build_type: "Release", cc: "clang", cxx: "clang++"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/HexDecimal/vcpkg
+	shallow = true

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,11 +3,7 @@
         {
             "name": "Win32",
             "includePath": [
-                "${workspaceFolder}/**",
-                "${vcpkgRoot}/x64-windows/include",
-                "${vcpkgRoot}/x64-windows-static/include",
-                "${vcpkgRoot}/x86-windows/include",
-                "${vcpkgRoot}/x86-windows-static/include"
+                "${workspaceFolder}/**"
             ],
             "defines": [
                 "_DEBUG",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(roguelike CXX)
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE
+        "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "Vcpkg toolchain file")
+endif()
+
+project(roguelike C CXX)
 
 file(GLOB_RECURSE SOURCE_FILES
     ${PROJECT_SOURCE_DIR}/src/*.cpp
@@ -8,17 +14,16 @@ file(GLOB_RECURSE SOURCE_FILES
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_SOURCE_DIR}/tcod/include
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
+find_package(libtcod CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} libtcod::libtcod)
 
 if (MSVC)
-    target_link_libraries(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/tcod/libtcod.lib)
     target_compile_options(${PROJECT_NAME} PRIVATE /W4)
 else()
-    target_link_libraries(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/tcod/libtcod.so)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
 endif()
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "pataro",
+    "version": "0.0.0",
+    "dependencies": [
+        "libtcod",
+        "sdl2"
+    ]
+}


### PR DESCRIPTION
Fixes #6 

I had to remove CI jobs which updated the Ubuntu compilers.  They had link errors since they did use the provided compilers consistently.  I'm not sure how to fix this yet.  Using the existing GCC works okay.

This is using my fork of the vcpkg repo.  This is just to get the latest version of libtcod before it's in the official repository.  You might need to switch to your own fork if you need your own ports.

Vcpkg is handled from CMake, so you don't need to do anything extra.  A full reconfigure is all you need to download or update the dependencies now.  You can also edit `vcpkg.json` to easily add new dependencies, such as the `fmt` library for example.